### PR TITLE
Issue 11 - Fixed caching, added clear_resource_cache

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ pytest-cov = "*"
 
 [packages]
 redis = "*"
+inject = "*"
 
 [requires]
 python_version = "3.5"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1122f628f33139d47bd91ff0321ed3c1a4adb7009963c1c3c12926c8038276f2"
+            "sha256": "4e6953d8ca889616384ac8b70d4f58ff044f5031ab83a533217a7c90a05216e8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,22 +16,30 @@
         ]
     },
     "default": {
-        "redis": {
+        "inject": {
             "hashes": [
-                "sha256:724932360d48e5407e8f82e405ab3650a36ed02c7e460d1e6fddf0f038422b54",
-                "sha256:9b19425a38fd074eb5795ff2b0d9a55b46a44f91f5347995f27e3ad257a7d775"
+                "sha256:557f5e4d62cb7ddd29a6f97f4fa6b2e5d892c4f908be573157c7841fc1021634",
+                "sha256:b63c15f146ab2ea7922190b8db8992b3915aa32e71fbc2b17a1c1f463ce5f2df"
             ],
             "index": "pypi",
-            "version": "==3.2.0"
+            "version": "==3.5.0"
+        },
+        "redis": {
+            "hashes": [
+                "sha256:6946b5dca72e86103edc8033019cc3814c031232d339d5f4533b02ea85685175",
+                "sha256:8ca418d2ddca1b1a850afa1680a7d2fd1f3322739271de4b704e0d4668449273"
+            ],
+            "index": "pypi",
+            "version": "==3.2.1"
         }
     },
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:35b032003d6a863f5dcd7ec11abd5cd5893428beaa31ab164982403bcb311f22",
-                "sha256:6a5d668d7dc69110de01cdf7aeec69a679ef486862a0850cc0fd5571505b6b7e"
+                "sha256:6560e1e1749f68c64a4b5dee4e091fce798d2f0d84ebe638cf0e0585a343acf4",
+                "sha256:b65db1bbaac9f9f4d190199bb8680af6f6f84fd3769a5ea883df8a91fe68b4c4"
             ],
-            "version": "==2.1.0"
+            "version": "==2.2.5"
         },
         "atomicwrites": {
             "hashes": [
@@ -42,46 +50,46 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
-                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
-            "version": "==18.2.0"
+            "version": "==19.1.0"
         },
         "coverage": {
             "hashes": [
-                "sha256:09e47c529ff77bf042ecfe858fb55c3e3eb97aac2c87f0349ab5a7efd6b3939f",
-                "sha256:0a1f9b0eb3aa15c990c328535655847b3420231af299386cfe5efc98f9c250fe",
-                "sha256:0cc941b37b8c2ececfed341444a456912e740ecf515d560de58b9a76562d966d",
-                "sha256:10e8af18d1315de936d67775d3a814cc81d0747a1a0312d84e27ae5610e313b0",
-                "sha256:1b4276550b86caa60606bd3572b52769860a81a70754a54acc8ba789ce74d607",
-                "sha256:1e8a2627c48266c7b813975335cfdea58c706fe36f607c97d9392e61502dc79d",
-                "sha256:2b224052bfd801beb7478b03e8a66f3f25ea56ea488922e98903914ac9ac930b",
-                "sha256:447c450a093766744ab53bf1e7063ec82866f27bcb4f4c907da25ad293bba7e3",
-                "sha256:46101fc20c6f6568561cdd15a54018bb42980954b79aa46da8ae6f008066a30e",
-                "sha256:4710dc676bb4b779c4361b54eb308bc84d64a2fa3d78e5f7228921eccce5d815",
-                "sha256:510986f9a280cd05189b42eee2b69fecdf5bf9651d4cd315ea21d24a964a3c36",
-                "sha256:5535dda5739257effef56e49a1c51c71f1d37a6e5607bb25a5eee507c59580d1",
-                "sha256:5a7524042014642b39b1fcae85fb37556c200e64ec90824ae9ecf7b667ccfc14",
-                "sha256:5f55028169ef85e1fa8e4b8b1b91c0b3b0fa3297c4fb22990d46ff01d22c2d6c",
-                "sha256:6694d5573e7790a0e8d3d177d7a416ca5f5c150742ee703f3c18df76260de794",
-                "sha256:6831e1ac20ac52634da606b658b0b2712d26984999c9d93f0c6e59fe62ca741b",
-                "sha256:77f0d9fa5e10d03aa4528436e33423bfa3718b86c646615f04616294c935f840",
-                "sha256:828ad813c7cdc2e71dcf141912c685bfe4b548c0e6d9540db6418b807c345ddd",
-                "sha256:85a06c61598b14b015d4df233d249cd5abfa61084ef5b9f64a48e997fd829a82",
-                "sha256:8cb4febad0f0b26c6f62e1628f2053954ad2c555d67660f28dfb1b0496711952",
-                "sha256:a5c58664b23b248b16b96253880b2868fb34358911400a7ba39d7f6399935389",
-                "sha256:aaa0f296e503cda4bc07566f592cd7a28779d433f3a23c48082af425d6d5a78f",
-                "sha256:ab235d9fe64833f12d1334d29b558aacedfbca2356dfb9691f2d0d38a8a7bfb4",
-                "sha256:b3b0c8f660fae65eac74fbf003f3103769b90012ae7a460863010539bb7a80da",
-                "sha256:bab8e6d510d2ea0f1d14f12642e3f35cefa47a9b2e4c7cea1852b52bc9c49647",
-                "sha256:c45297bbdbc8bb79b02cf41417d63352b70bcb76f1bbb1ee7d47b3e89e42f95d",
-                "sha256:d19bca47c8a01b92640c614a9147b081a1974f69168ecd494687c827109e8f42",
-                "sha256:d64b4340a0c488a9e79b66ec9f9d77d02b99b772c8b8afd46c1294c1d39ca478",
-                "sha256:da969da069a82bbb5300b59161d8d7c8d423bc4ccd3b410a9b4d8932aeefc14b",
-                "sha256:ed02c7539705696ecb7dc9d476d861f3904a8d2b7e894bd418994920935d36bb",
-                "sha256:ee5b8abc35b549012e03a7b1e86c09491457dba6c94112a2482b18589cc2bdb9"
+                "sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9",
+                "sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74",
+                "sha256:3c205bc11cc4fcc57b761c2da73b9b72a59f8d5ca89979afb0c1c6f9e53c7390",
+                "sha256:465ce53a8c0f3a7950dfb836438442f833cf6663d407f37d8c52fe7b6e56d7e8",
+                "sha256:48020e343fc40f72a442c8a1334284620f81295256a6b6ca6d8aa1350c763bbe",
+                "sha256:5296fc86ab612ec12394565c500b412a43b328b3907c0d14358950d06fd83baf",
+                "sha256:5f61bed2f7d9b6a9ab935150a6b23d7f84b8055524e7be7715b6513f3328138e",
+                "sha256:68a43a9f9f83693ce0414d17e019daee7ab3f7113a70c79a3dd4c2f704e4d741",
+                "sha256:6b8033d47fe22506856fe450470ccb1d8ba1ffb8463494a15cfc96392a288c09",
+                "sha256:7ad7536066b28863e5835e8cfeaa794b7fe352d99a8cded9f43d1161be8e9fbd",
+                "sha256:7bacb89ccf4bedb30b277e96e4cc68cd1369ca6841bde7b005191b54d3dd1034",
+                "sha256:839dc7c36501254e14331bcb98b27002aa415e4af7ea039d9009409b9d2d5420",
+                "sha256:8f9a95b66969cdea53ec992ecea5406c5bd99c9221f539bca1e8406b200ae98c",
+                "sha256:932c03d2d565f75961ba1d3cec41ddde00e162c5b46d03f7423edcb807734eab",
+                "sha256:988529edadc49039d205e0aa6ce049c5ccda4acb2d6c3c5c550c17e8c02c05ba",
+                "sha256:998d7e73548fe395eeb294495a04d38942edb66d1fa61eb70418871bc621227e",
+                "sha256:9de60893fb447d1e797f6bf08fdf0dbcda0c1e34c1b06c92bd3a363c0ea8c609",
+                "sha256:9e80d45d0c7fcee54e22771db7f1b0b126fb4a6c0a2e5afa72f66827207ff2f2",
+                "sha256:a545a3dfe5082dc8e8c3eb7f8a2cf4f2870902ff1860bd99b6198cfd1f9d1f49",
+                "sha256:a5d8f29e5ec661143621a8f4de51adfb300d7a476224156a39a392254f70687b",
+                "sha256:aca06bfba4759bbdb09bf52ebb15ae20268ee1f6747417837926fae990ebc41d",
+                "sha256:bb23b7a6fd666e551a3094ab896a57809e010059540ad20acbeec03a154224ce",
+                "sha256:bfd1d0ae7e292105f29d7deaa9d8f2916ed8553ab9d5f39ec65bcf5deadff3f9",
+                "sha256:c62ca0a38958f541a73cf86acdab020c2091631c137bd359c4f5bddde7b75fd4",
+                "sha256:c709d8bda72cf4cd348ccec2a4881f2c5848fd72903c185f363d361b2737f773",
+                "sha256:c968a6aa7e0b56ecbd28531ddf439c2ec103610d3e2bf3b75b813304f8cb7723",
+                "sha256:df785d8cb80539d0b55fd47183264b7002077859028dfe3070cf6359bf8b2d9c",
+                "sha256:f406628ca51e0ae90ae76ea8398677a921b36f0bd71aab2099dfed08abd0322f",
+                "sha256:f46087bbd95ebae244a0eda01a618aff11ec7a069b15a3ef8f6b520db523dcf1",
+                "sha256:f8019c5279eb32360ca03e9fac40a12667715546eed5c5eb59eb381f2f501260",
+                "sha256:fc5f4d209733750afd2714e9109816a29500718b32dd9a5db01c0cb3a019b96a"
             ],
-            "version": "==4.5.2"
+            "version": "==4.5.3"
         },
         "falcon": {
             "hashes": [
@@ -101,11 +109,10 @@
         },
         "isort": {
             "hashes": [
-                "sha256:1153601da39a25b14ddc54955dbbacbb6b2d19135386699e2ad58517953b34af",
-                "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
-                "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497"
+                "sha256:01cb7e1ca5e6c5b3f235f0385057f70558b70d2f00320208825fa62887292f43",
+                "sha256:268067462aed7eb2a1e237fcb287852f22077de3fb07964e87e00f829eea2d1a"
             ],
-            "version": "==4.3.4"
+            "version": "==4.3.17"
         },
         "lazy-object-proxy": {
             "hashes": [
@@ -150,11 +157,11 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:0125e8f60e9e031347105eb1682cef932f5e97d7b9a1a28d9bf00c22a5daef40",
-                "sha256:590044e3942351a1bdb1de960b739ff4ce277960f2425ad4509446dbace8d9d1"
+                "sha256:2112d2ca570bb7c3e53ea1a35cd5df42bb0fd10c45f0fb97178679c3c03d64c7",
+                "sha256:c3e4748ba1aad8dba30a4886b0b1a2004f9a863837b8654e7059eebf727afa5a"
             ],
             "markers": "python_version > '2.7'",
-            "version": "==6.0.0"
+            "version": "==7.0.0"
         },
         "pathlib2": {
             "hashes": [
@@ -166,33 +173,33 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:8ddc32f03971bfdf900a81961a48ccf2fb677cf7715108f85295c67405798616",
-                "sha256:980710797ff6a041e9a73a5787804f848996ecaa6f8a1b1e08224a5894f2074a"
+                "sha256:19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f",
+                "sha256:84d306a647cc805219916e62aab89caa97a33a1dd8c342e87a37f91073cd4746"
             ],
-            "version": "==0.8.1"
+            "version": "==0.9.0"
         },
         "py": {
             "hashes": [
-                "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
-                "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
+                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
+                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
             ],
-            "version": "==1.7.0"
+            "version": "==1.8.0"
         },
         "pylint": {
             "hashes": [
-                "sha256:689de29ae747642ab230c6d37be2b969bf75663176658851f456619aacf27492",
-                "sha256:771467c434d0d9f081741fec1d64dfb011ed26e65e12a28fe06ca2f61c4d556c"
+                "sha256:5d77031694a5fb97ea95e828c8d10fc770a1df6eb3906067aaed42201a8a6a09",
+                "sha256:723e3db49555abaf9bf79dc474c6b9e2935ad82230b10c1138a71ea41ac0fff1"
             ],
             "index": "pypi",
-            "version": "==2.2.2"
+            "version": "==2.3.1"
         },
         "pytest": {
             "hashes": [
-                "sha256:067a1d4bf827ffdd56ad21bd46674703fce77c5957f6c1eef731f6146bfcef1c",
-                "sha256:9687049d53695ad45cf5fdc7bbd51f0c49f1ea3ecfc4b7f3fde7501b541f17f4"
+                "sha256:3773f4c235918987d51daf1db66d51c99fac654c81d6f2f709a046ab446d5e5d",
+                "sha256:b7802283b70ca24d7119b32915efa7c409982f59913c1a6c0640aacf118b95f5"
             ],
             "index": "pypi",
-            "version": "==4.3.0"
+            "version": "==4.4.1"
         },
         "pytest-cov": {
             "hashes": [
@@ -238,7 +245,7 @@
                 "sha256:d659517ca116e6750101a1326107d3479028c5191f0ecee3c7203c50f5b915b0",
                 "sha256:eddd3fb1f3e0f82e5915a899285a39ee34ce18fd25d89582bc89fc9fb16cd2c6"
             ],
-            "markers": "python_version < '3.7' and implementation_name == 'cpython'",
+            "markers": "implementation_name == 'cpython'",
             "version": "==1.3.1"
         },
         "wrapt": {

--- a/falcon_redis_cache/middleware.py
+++ b/falcon_redis_cache/middleware.py
@@ -20,7 +20,7 @@ class RedisCacheMiddleware(object):
 
     def process_resource(self, req, resp, resource, params):
         """Provide redis cache with every request."""
-        if hasattr(resource, 'use_cache') and resource.use_cache:
+        if isinstance(resource, CacheCompaitableResource) and resource.use_cache:
             req.context.setdefault('params', params)
             resp.context.setdefault('cached', self.client.get(cache_key(req, resource)))
 

--- a/falcon_redis_cache/middleware.py
+++ b/falcon_redis_cache/middleware.py
@@ -47,5 +47,5 @@ class RedisCacheMiddleware(object):
                     self.client.delete(_cache)
                     if resc.cache_with_query:
                         # for resources using query strings
-                        for key in self.client.scan_iter(_cache):
+                        for key in self.client.scan_iter('{}*'.format(_cache[:-1])):
                             self.client.delete(key)

--- a/falcon_redis_cache/utils.py
+++ b/falcon_redis_cache/utils.py
@@ -27,5 +27,5 @@ def clear_resource_cache(resource, req, redis_client=None, **params):
         redis_client.delete(_cache)
         if resource.cache_with_query:
             # for resources using query strings
-            for key in redis_client.scan_iter(_cache):
-                self.client.delete(key)
+            for key in redis_client.scan_iter('{}*'.format(_cache[:-1])):
+                redis_client.delete(key)

--- a/falcon_redis_cache/utils.py
+++ b/falcon_redis_cache/utils.py
@@ -1,0 +1,31 @@
+import inject
+import redis
+from logging import warning
+from string import Template
+from .resource import CacheCompaitableResource
+
+
+def cache_key(req, resource, uri=None):
+    """Provides unique redis cache key."""
+    uri = uri or req.uri
+    if uri.endswith('/'):
+        uri = uri[:-1]
+    if resource.unique_cache:
+        if req.auth:
+            return '{}+{}'.format(uri, req.auth)
+        warning(req, 'Could not construct unique key for uri "{}"'.format(uri))
+    return uri
+
+
+@inject.params(redis_client=redis.Redis)
+def clear_resource_cache(resource, req, redis_client=None, **params):
+    if issubclass(resource, CacheCompaitableResource) and redis_client:
+        tmpl = resource.route.replace('{', '${')
+        route = Template(tmpl).safe_substitute(**params)
+        uri = '{}://{}{}'.format(req.scheme, req.netloc, route)
+        _cache = cache_key(req, resource, uri)
+        redis_client.delete(_cache)
+        if resource.cache_with_query:
+            # for resources using query strings
+            for key in redis_client.scan_iter(_cache):
+                self.client.delete(key)

--- a/tests/falcon/app.py
+++ b/tests/falcon/app.py
@@ -2,11 +2,12 @@
 import falcon
 from falcon_redis_cache.middleware import RedisCacheMiddleware
 from tests.falcon.constants import REDIS_HOST, REDIS_PORT
-from tests.falcon.resource import TestResource, TestUniqueResource, TestCollectionResource, DebugResource
+from tests.falcon.resource import TestResource, TestBindedResource, TestUniqueResource, TestCollectionResource, DebugResource
 
 api = falcon.API(middleware=[RedisCacheMiddleware(redis_host=REDIS_HOST, redis_port=REDIS_PORT)])
 
 api.add_route(TestResource.route, TestResource())
+api.add_route(TestBindedResource.route, TestBindedResource())
 api.add_route(TestUniqueResource.route, TestUniqueResource())
 api.add_route(TestCollectionResource.route, TestCollectionResource())
 api.add_route(DebugResource.route, DebugResource())

--- a/tests/falcon/resource.py
+++ b/tests/falcon/resource.py
@@ -87,7 +87,7 @@ class TestBindedResource(CacheCompaitableResource):
     route = '/test/binded/{test_id}/action'
 
     def on_post(self, req, resp, test_id):
-        clear_resource_cache(TestResource, req)
+        clear_resource_cache(TestResource, req, test_id=test_id)
 
 
 class TestUniqueResource(TestResource):

--- a/tests/falcon/resource.py
+++ b/tests/falcon/resource.py
@@ -1,11 +1,13 @@
+import falcon
+import inject
 import json
+import os
 import redis
 import time
-import os
-import falcon
 from falcon.errors import HTTPBadRequest, HTTPNotFound
 from falcon_redis_cache.hooks import CacheProvider
 from falcon_redis_cache.resource import CacheCompaitableResource
+from falcon_redis_cache.utils import clear_resource_cache
 
 from tests.falcon.constants import REDIS_HOST, REDIS_PORT
 
@@ -80,6 +82,14 @@ class TestResource(CacheCompaitableResource):
             raise HTTPNotFound()
 
 
+class TestBindedResource(CacheCompaitableResource):
+
+    route = '/test/binded/{test_id}/action'
+
+    def on_post(self, req, resp, test_id):
+        clear_resource_cache(TestResource, req)
+
+
 class TestUniqueResource(TestResource):
 
     route = '/test/unique/{test_id}/'
@@ -103,3 +113,5 @@ class TestCollectionResource(CacheCompaitableResource):
 
 
 TestResource.binded_resources = [TestCollectionResource]
+# configure injector to use redis client
+inject.configure(lambda binder: binder.bind(redis.Redis, redis.StrictRedis(host=REDIS_HOST, port=REDIS_PORT)))

--- a/tests/test_falcon_cache.py
+++ b/tests/test_falcon_cache.py
@@ -7,6 +7,7 @@ from tests.falcon.resource import MAX_SLEEP_TIME
 
 class HrefMap(object):
     TEST = '/test/{test_id}/'
+    TEST_BINDED = '/test/binded/{test_id}/action/'
     TEST_UNIQUE = '/test/unique/{test_id}/'
     COLLECTION = '/test/'
     DEBUG = '/test/debug/'
@@ -34,16 +35,36 @@ class FalconCacheTest(testing.TestCase):
         wipe_res = self.simulate_delete(HrefMap.DEBUG)
         self.assertEqual(wipe_res.status_code, 204)
 
+    def assertUncachedResponse(self, res):
+        self.assertGreaterEqual(res.elapsed_time, MAX_RESPONSE_TIME)
+        self.assertGreaterEqual(MAX_SLEEP_TIME + MAX_RESPONSE_TIME, res.elapsed_time)
+
+    def assertCachedResponse(self, res):
+        self.assertLessEqual(res.elapsed_time, MAX_SLEEP_TIME)
+
     def test_base_cache(self):
         # response should not be cached
         res = self.simulate_get(HrefMap.COLLECTION)
         self.assertEqual(res.status_code, 200)
-        self.assertGreaterEqual(MAX_SLEEP_TIME + MAX_RESPONSE_TIME, res.elapsed_time)
+        self.assertUncachedResponse(res)
         # response should now be cached
         cached_res = self.simulate_get(HrefMap.COLLECTION)
         self.assertEqual(cached_res.status_code, 200)
-        self.assertLess(cached_res.elapsed_time, res.elapsed_time)
-        self.assertLessEqual(cached_res.elapsed_time, MAX_SLEEP_TIME)
+        self.assertCachedResponse(cached_res)
+
+    def test_binded(self):
+        res = self.simulate_get(HrefMap.COLLECTION)
+        self.assertEqual(res.status_code, 200)
+        test_id = res.json[-1].get('_id')
+        resource_res = self.simulate_get(HrefMap.TEST.format(test_id=test_id))
+        self.assertEqual(resource_res.status_code, 200)
+        self.assertUncachedResponse(resource_res)
+        cached_resource_res = self.simulate_get(HrefMap.TEST.format(test_id=test_id))
+        self.assertCachedResponse(cached_resource_res)
+        binded_res = self.simulate_post(HrefMap.TEST_BINDED.format(test_id=test_id))
+        self.assertEqual(binded_res.status_code, 200)
+        cleared_cache_res = self.simulate_get(HrefMap.TEST.format(test_id=test_id))
+        self.assertUncachedResponse(cleared_cache_res)
 
     def test_unique_cache(self):
         res = self.simulate_get(HrefMap.COLLECTION)
@@ -53,34 +74,33 @@ class FalconCacheTest(testing.TestCase):
         # response for unique resource should not be cached
         resource_res = self.simulate_get(HrefMap.TEST_UNIQUE.format(test_id=test_id), headers=headers)
         self.assertEqual(resource_res.status_code, 200)
-        self.assertGreaterEqual(MAX_SLEEP_TIME + MAX_RESPONSE_TIME, resource_res.elapsed_time)
+        self.assertUncachedResponse(resource_res)
         # response with unique resource is not cached
         cached_resource_res = self.simulate_get(HrefMap.TEST_UNIQUE.format(test_id=test_id), headers=headers)
-        self.assertLessEqual(cached_resource_res.elapsed_time, MAX_SLEEP_TIME)
+        self.assertCachedResponse(cached_resource_res)
         # response should not be cached using new auth header
         resource_res_unauthorized = self.simulate_get(HrefMap.TEST_UNIQUE.format(test_id=test_id), headers={
             'Authorization': 'somenewkey'})
-        self.assertGreaterEqual(MAX_SLEEP_TIME + MAX_RESPONSE_TIME, resource_res_unauthorized.elapsed_time)
+        self.assertUncachedResponse(resource_res_unauthorized)
 
     def test_cache_with_query(self):
         params = {'start': 5, 'count': 5}
         # response should not be cached
         res = self.simulate_get(HrefMap.COLLECTION, params=params)
         self.assertEqual(res.status_code, 200)
-        self.assertGreaterEqual(MAX_SLEEP_TIME + MAX_RESPONSE_TIME, res.elapsed_time)
+        self.assertUncachedResponse(res)
         # response should now be cached
         cached_res = self.simulate_get(HrefMap.COLLECTION, params=params)
         self.assertEqual(cached_res.status_code, 200)
-        self.assertLess(cached_res.elapsed_time, res.elapsed_time)
-        self.assertLessEqual(cached_res.elapsed_time, MAX_SLEEP_TIME)
+        self.assertCachedResponse(cached_res)
         # response with different params should not be cached
         res = self.simulate_get(HrefMap.COLLECTION, params={'start': 10, 'count': 5})
         self.assertEqual(res.status_code, 200)
-        self.assertGreaterEqual(MAX_SLEEP_TIME + MAX_RESPONSE_TIME, res.elapsed_time)
+        self.assertUncachedResponse(res)
         # invalid should wipe all cache
         test_id = res.json[-1].get('_id')
         delete_res = self.simulate_delete(HrefMap.TEST.format(test_id=test_id))
         self.assertEqual(delete_res.status_code, 204)
         res = self.simulate_get(HrefMap.COLLECTION, params=params)
         # assumes cache binding works, invalidates requests with query strings as well
-        self.assertGreaterEqual(MAX_SLEEP_TIME + MAX_RESPONSE_TIME, res.elapsed_time)
+        self.assertUncachedResponse(res)


### PR DESCRIPTION
In this pull request I've fixed the caching mechanisms for keys with query strings, cleaned up the tests, implemented python-inject, and implemented a new utility for clearing resource caches (for scenarios where binding is not possible).

Related issue: [Issue 11](https://github.com/neetjn/falcon-redis-cache/issues/11)